### PR TITLE
Update prototypes.md

### DIFF
--- a/libs/minilibx/prototypes.md
+++ b/libs/minilibx/prototypes.md
@@ -370,9 +370,9 @@ Converts an xpm file to a new image instance.
 void    *mlx_xpm_file_to_image(void *mlx_ptr, char *filename, int *width, int *height);
 ```
 
-### mlx_png_file_to_image
+### mlx_png_file_to_image (macOS only)
 
-Converts a png file to a new image instance.
+Converts a png file to a new image instance. Not implemented for [minilibx-linux](https://github.com/42Paris/minilibx-linux)
 
 ```c
 /*

--- a/libs/minilibx/prototypes.md
+++ b/libs/minilibx/prototypes.md
@@ -386,7 +386,7 @@ Converts a png file to a new image instance. Not implemented for [minilibx-linux
 **                         instead;
 ** @return void *          the image instance.
 */
-void    *mlx_xpm_file_to_image(void *mlx_ptr, char *filename, int *width, int *height);
+void    *mlx_png_file_to_image(void *mlx_ptr, char *filename, int *width, int *height);
 ```
 
 ## Mouse functions


### PR DESCRIPTION
mlx_png.c and mlx_png.h are not included in the the minilibx-linux

https://github.com/42Paris/minilibx-linux

mlx_png_file_to_image (macOS only)

Converts a png file to a new image instance.	Converts a png file to a new image instance. Not implemented for [minilibx-linux](https://github.com/42Paris/minilibx-linux)