### PR TITLE
Getting Started: add link to the github repo of MiniLibX for linux

### DIFF
--- a/libs/minilibx/getting_started.md
+++ b/libs/minilibx/getting_started.md
@@ -52,7 +52,7 @@ target as it is a dynamic library!
 
 ## Compilation on Linux
 
-In case of Linux, you can use the Codam provided zip which is a linux
+In case of Linux, you can use the [Codam provided zip](https://github.com/42Paris/minilibx-linux) which is a linux
 compatible MLX version. It has the exact same functions and shares the same
 function calls. Do mind, that using memory magic on images can differ as object
 implementations are architecture specific. Next, you should unzip the MLX


### PR DESCRIPTION
Hi, great work on this site! Saves a bunch of time that would be otherwise spent on navigating poorly documented sources.

In [Getting Started -> Compilation on Linux](https://harm-smits.github.io/42docs/libs/minilibx/getting_started.html#compilation-on-linux) you mention Codam provided zip, which, I assume, is provided with Cub3d subject in Codam.
However, on my campus, it is not provided and I've wasted quite a bit of time trying to find it. 
Turns out it's hosted right here on github: https://github.com/42Paris/minilibx-linux

Please, add the link for those unfortunate souls who also don't recieve this file with their subject.
Thanks!