### PR TITLE
update $(OBJ).

### DIFF
--- a/libs/minilibx/getting_started.md
+++ b/libs/minilibx/getting_started.md
@@ -44,7 +44,7 @@ To link with the required internal macOS API:
 
 ```makefile
 $(NAME): $(OBJ)
-	$(CC) -Lmlx -lmlx -framework OpenGL -framework AppKit $(OBJ) -o $(NAME)
+	$(CC) $(OBJ) -Lmlx -lmlx -framework OpenGL -framework AppKit -o $(NAME)
 ```
 
 Do mind that you need the `libmlx.dylib` in the same directory as your build
@@ -80,7 +80,7 @@ To link with the required internal Linux API:
 
 ```makefile
 $(NAME): $(OBJ)
-	$(CC) -Lmlx_linux -lmlx_linux -L/usr/lib -Imlx_linux -lXext -lX11 -lm -lz $(OBJ) -o $(NAME)
+	$(CC) $(OBJ) -Lmlx_linux -lmlx_linux -L/usr/lib -Imlx_linux -lXext -lX11 -lm -lz -o $(NAME)
 ```
 
 ## Getting a screen on WSL2


### PR DESCRIPTION
fix $(OBJ) argument locations on commend. 🤖
why change?
When I clean my project and use ```make```, I get the error if the link is currently makefile with another makefile, and better keep $(OBJ) first.
