### PR TITLE
change -lmlx_linux to -lmlx_Linux

### DIFF
--- a/libs/minilibx/getting_started.md
+++ b/libs/minilibx/getting_started.md
@@ -82,7 +82,7 @@ To link with the required internal Linux API:
 
 ```makefile
 $(NAME): $(OBJ)
-	$(CC) $(OBJ) -Lmlx_linux -lmlx_linux -L/usr/lib -Imlx_linux -lXext -lX11 -lm -lz -o $(NAME)
+	$(CC) $(OBJ) -Lmlx_linux -lmlx_Linux -L/usr/lib -Imlx_linux -lXext -lX11 -lm -lz -o $(NAME)
 ```
 
 ### Getting a screen on Windows 10 (WSL2)


### PR DESCRIPTION
In the [getting started section](https://harm-smits.github.io/42docs/libs/minilibx/getting_started.html)
I've corrected the `-lmlx_linux`  to `-lmlx_Linux`